### PR TITLE
Remove bracketed tags from TMDB search queries

### DIFF
--- a/core/tmdb.py
+++ b/core/tmdb.py
@@ -846,7 +846,7 @@ class Tmdb(object):
         self.searched_text = kwargs.get('searched_text', '')
 
         self.search_id = kwargs.get('id_Tmdb', '')
-        self.search_text = re.sub('\[\\\?(B|I|COLOR)\s?[^\]]*\]', '', self.searched_text).strip()
+        self.search_text = re.sub('\[[^\]]+\]', '', self.searched_text).strip()
         self.search_type = kwargs.get('search_type', '')
         self.search_language = kwargs.get('search_language', def_lang)
         self.fallback_language = 'en'


### PR DESCRIPTION
Updated the regex used to clean the search text before requesting TMDB data.

Previously, only specific formatting tags were removed (e.g. [?B], [?I], [?COLOR]), but some titles include arbitrary labels like [CORTO], which cause TMDB to return no results.

Now all bracketed text is stripped, ensuring correct title matching.