### PR TITLE
Aggiunta preferenza audio/sottotitoli per interi episodi di una serie dalla videoteca

### DIFF
--- a/platformcode/contextmenu/tvshow_options.py
+++ b/platformcode/contextmenu/tvshow_options.py
@@ -151,6 +151,10 @@ def get_menu_items():
             else:
                 items.append((config.get_localized_string(80049), lambda: xbmc.executebuiltin("RunPlugin(plugin://plugin.video.s4me/?{}&action=remove_local_episodes&channel=videolibrary&path={})".format(item_url, path))))
 
+            # Context menu: Set preferred audio language and subtitle for this series
+            items.append((config.get_localized_string(80051),
+                          lambda: xbmc.executebuiltin("RunPlugin(plugin://plugin.video.s4me/?{}&action=set_tvshow_media_prefs&channel=videolibrary)".format(item_url))))
+
             # Context menu: Delete series / channel
             channels_num = len(item.library_urls)
             if channels_num > 1:

--- a/platformcode/platformtools.py
+++ b/platformcode/platformtools.py
@@ -1530,6 +1530,9 @@ def set_player(item, xlistitem, mediaurl, view, strm):
             playlist = xbmc.PlayList(xbmc.PLAYLIST_VIDEO)
             playlist.clear()
             playlist.add(mediaurl, xlistitem)
+            # Imposta lingua audio/sottotitoli di Kodi PRIMA del play
+            from platformcode import xbmc_videolibrary as _xvl
+            item._original_lang_prefs = _xvl._set_kodi_lang_prefs(item)
             # Reproduce
             xbmc_player.play(playlist, xlistitem)
             add_next_to_playlist(item)

--- a/platformcode/xbmc_videolibrary.py
+++ b/platformcode/xbmc_videolibrary.py
@@ -75,26 +75,29 @@ def _set_kodi_lang_prefs(item):
         original['subtitles.languages'] = res.get('result', {}).get('value', '')
 
         # Imposta lingua audio
+        changed = False
         if audio_lang and audio_lang in _LANG_KODI:
             _json_rpc('Settings.SetSettingValue', {
                 'setting': 'locale.audiolanguage',
                 'value': _LANG_KODI[audio_lang]
             })
             logger.debug("_set_kodi_lang_prefs: audio -> %s" % _LANG_KODI[audio_lang])
+            changed = True
 
         # Imposta lingua sottotitoli
         if sub_lang == '__off__':
             # Kodi non ha un "forza spento" pre-play, gestiamo post-play
             pass
-        elif sub_lang == '__on__':
-            pass  # Usa la lingua sottotitoli già impostata dall'utente
         elif sub_lang in _LANG_KODI:
             _json_rpc('Settings.SetSettingValue', {
                 'setting': 'locale.subtitlelanguage',
                 'value': _LANG_KODI[sub_lang]
             })
             logger.debug("_set_kodi_lang_prefs: subtitle lang -> %s" % _LANG_KODI[sub_lang])
+            changed = True
 
+        if not changed:
+            return None
         return original
 
     except Exception as e:
@@ -137,10 +140,10 @@ def _apply_media_prefs(item, original_lang_prefs=None):
             head_nfo, tvshow_item = videolibrarytools.read_nfo(nfo)
             prefs = getattr(tvshow_item, 'tvshow_media_prefs', None)
             if prefs:
-                sub_lang = prefs.get('sub_lang', '__on__')
+                sub_lang = prefs.get('sub_lang', '')
 
         # Se non c'è nulla da fare, esci subito
-        needs_av = (sub_lang in ('__on__', '__off__')) or (original_lang_prefs is not None)
+        needs_av = (sub_lang == '__off__') or (original_lang_prefs is not None)
         if not needs_av:
             return
 
@@ -171,14 +174,11 @@ def _apply_media_prefs(item, original_lang_prefs=None):
         # Ora Kodi ha selezionato le tracce: ripristina le impostazioni originali
         _restore_kodi_lang_prefs(original_lang_prefs)
 
-        # Gestisci __on__/__off__ sottotitoli
+        # Gestisci __off__ sottotitoli
         player = xbmc.Player()
         if sub_lang == '__off__':
             player.showSubtitles(False)
             logger.debug("_apply_media_prefs: sottotitoli disabilitati")
-        elif sub_lang == '__on__':
-            player.showSubtitles(True)
-            logger.debug("_apply_media_prefs: sottotitoli abilitati (lingua default)")
 
     except Exception as e:
         logger.error("_apply_media_prefs: errore generale: %s" % str(e))

--- a/platformcode/xbmc_videolibrary.py
+++ b/platformcode/xbmc_videolibrary.py
@@ -20,6 +20,140 @@ from core import scrapertools
 from xml.dom import minidom
 
 
+# Mappa di alias linguistici per il riconoscimento delle tracce audio/sottotitoli.
+# Le chiavi corrispondono ai valori salvati in tvshow_media_prefs.
+_LANG_ALIASES = {
+    'ita': ['ita', 'italiano', 'italian', 'it'],
+    'eng': ['eng', 'english', 'en'],
+    'spa': ['spa', 'espanol', 'spanish', 'es'],
+    'fra': ['fra', 'francais', 'french', 'fr'],
+    'deu': ['deu', 'deutsch', 'german', 'de'],
+    'por': ['por', 'portugues', 'portuguese', 'pt'],
+    'jpn': ['jpn', 'japanese', 'ja'],
+}
+
+
+def _apply_media_prefs(item):
+    """
+    Applica le preferenze audio/sottotitoli salvate in tvshow.nfo dopo l'avvio
+    della riproduzione. Chiamata da mark_as_watched_subThread().
+    """
+    try:
+        nfo = item.nfo
+        if not nfo or not str(nfo).endswith('tvshow.nfo'):
+            return
+        if not filetools.exists(nfo):
+            return
+
+        from core import videolibrarytools
+        head_nfo, tvshow_item = videolibrarytools.read_nfo(nfo)
+        prefs = getattr(tvshow_item, 'tvshow_media_prefs', None)
+        if not prefs:
+            return
+
+        audio_lang = prefs.get('audio_lang', '')
+        sub_lang   = prefs.get('sub_lang',   '__on__')
+        if not audio_lang and not sub_lang:
+            return
+
+        # Attende che le tracce siano disponibili (1.5 secondi dopo l'avvio)
+        for _ in range(3):
+            if not platformtools.is_playing():
+                return
+            time.sleep(0.5)
+
+        if not platformtools.is_playing():
+            return
+
+        player = xbmc.Player()
+
+        # Imposta la traccia audio
+        if audio_lang:
+            try:
+                streams = player.getAvailableAudioStreams()
+                aliases = _LANG_ALIASES.get(audio_lang, [audio_lang])
+                # Prima passa: cerca tracce non-FORCED
+                found = False
+                for i, label in enumerate(streams):
+                    s = label.lower()
+                    if 'forced' in s:
+                        continue
+                    for alias in aliases:
+                        if alias.lower() in s:
+                            player.setAudioStream(i)
+                            logger.debug("_apply_media_prefs: audio stream %d selezionato: %s" % (i, label))
+                            found = True
+                            break
+                    if found:
+                        break
+                # Seconda passa: accetta anche FORCED se non trovato nulla
+                if not found:
+                    for i, label in enumerate(streams):
+                        s = label.lower()
+                        for alias in aliases:
+                            if alias.lower() in s:
+                                player.setAudioStream(i)
+                                logger.debug("_apply_media_prefs: audio stream (forced) %d selezionato: %s" % (i, label))
+                                found = True
+                                break
+                        if found:
+                            break
+                if not found:
+                    logger.debug("_apply_media_prefs: nessuna traccia audio corrisponde a '%s'" % audio_lang)
+            except Exception as e:
+                logger.error("_apply_media_prefs: errore impostando audio: %s" % str(e))
+
+        # Imposta i sottotitoli
+        if sub_lang:
+            try:
+                if sub_lang == '__off__':
+                    # Forza sottotitoli spenti
+                    player.showSubtitles(False)
+                    logger.debug("_apply_media_prefs: sottotitoli disabilitati")
+                elif sub_lang == '__on__':
+                    # Abilita sottotitoli senza cambiare la traccia
+                    player.showSubtitles(True)
+                    logger.debug("_apply_media_prefs: sottotitoli abilitati (lingua default)")
+                else:
+                    streams = player.getAvailableSubtitleStreams()
+                    aliases = _LANG_ALIASES.get(sub_lang, [sub_lang])
+                    # Prima passa: cerca tracce non-FORCED
+                    found = False
+                    for i, label in enumerate(streams):
+                        s = label.lower()
+                        if 'forced' in s:
+                            continue
+                        for alias in aliases:
+                            if alias.lower() in s:
+                                player.setSubtitleStream(i)
+                                player.showSubtitles(True)
+                                logger.debug("_apply_media_prefs: sottotitolo stream %d selezionato: %s" % (i, label))
+                                found = True
+                                break
+                        if found:
+                            break
+                    # Seconda passa: accetta anche FORCED se non trovato nulla
+                    if not found:
+                        for i, label in enumerate(streams):
+                            s = label.lower()
+                            for alias in aliases:
+                                if alias.lower() in s:
+                                    player.setSubtitleStream(i)
+                                    player.showSubtitles(True)
+                                    logger.debug("_apply_media_prefs: sottotitolo stream (forced) %d selezionato: %s" % (i, label))
+                                    found = True
+                                    break
+                            if found:
+                                break
+                    if not found:
+                        logger.debug("_apply_media_prefs: nessun sottotitolo corrisponde a '%s'" % sub_lang)
+            except Exception as e:
+                logger.error("_apply_media_prefs: errore impostando sottotitoli: %s" % str(e))
+
+    except Exception as e:
+        logger.error("_apply_media_prefs: errore generale: %s" % str(e))
+
+
 def mark_auto_as_watched(item):
     def mark_as_watched_subThread(item):
         logger.debug()
@@ -29,6 +163,8 @@ def mark_auto_as_watched(item):
         time_limit = time.time() + 10
         while not platformtools.is_playing() and time.time() < time_limit:
             time.sleep(1)
+
+        _apply_media_prefs(item)
 
         marked = False
         sync = False

--- a/platformcode/xbmc_videolibrary.py
+++ b/platformcode/xbmc_videolibrary.py
@@ -20,138 +20,169 @@ from core import scrapertools
 from xml.dom import minidom
 
 
-# Mappa di alias linguistici per il riconoscimento delle tracce audio/sottotitoli.
-# Le chiavi corrispondono ai valori salvati in tvshow_media_prefs.
-_LANG_ALIASES = {
-    'ita': ['ita', 'italiano', 'italian', 'it'],
-    'eng': ['eng', 'english', 'en'],
-    'spa': ['spa', 'espanol', 'spanish', 'es'],
-    'fra': ['fra', 'francais', 'french', 'fr'],
-    'deu': ['deu', 'deutsch', 'german', 'de'],
-    'por': ['por', 'portugues', 'portuguese', 'pt'],
-    'jpn': ['jpn', 'japanese', 'ja'],
+# Mappa codici lingua -> nome ISO 639-1 / BCP47 che Kodi accetta in locale settings
+_LANG_KODI = {
+    'ita': 'Italian',
+    'eng': 'English',
+    'spa': 'Spanish',
+    'fra': 'French',
+    'deu': 'German',
+    'por': 'Portuguese',
+    'jpn': 'Japanese',
 }
 
 
-def _apply_media_prefs(item):
+def _set_kodi_lang_prefs(item):
     """
-    Applica le preferenze audio/sottotitoli salvate in tvshow.nfo dopo l'avvio
-    della riproduzione. Chiamata da mark_as_watched_subThread().
+    Imposta temporaneamente la lingua audio/sottotitoli di Kodi tramite JSON-RPC
+    PRIMA dell'avvio della riproduzione, in modo che Kodi scelga la traccia
+    giusta fin dall'inizio senza alcun cambio visibile.
+    Ritorna un dict con i valori originali da ripristinare dopo la riproduzione.
     """
     try:
         nfo = item.nfo
         if not nfo or not str(nfo).endswith('tvshow.nfo'):
-            return
+            return None
         if not filetools.exists(nfo):
-            return
+            return None
 
         from core import videolibrarytools
         head_nfo, tvshow_item = videolibrarytools.read_nfo(nfo)
         prefs = getattr(tvshow_item, 'tvshow_media_prefs', None)
         if not prefs:
-            return
+            return None
 
         audio_lang = prefs.get('audio_lang', '')
         sub_lang   = prefs.get('sub_lang',   '__on__')
         if not audio_lang and not sub_lang:
-            return
+            return None
 
-        # Attende che le tracce siano disponibili (1.5 secondi dopo l'avvio)
-        for _ in range(3):
-            if not platformtools.is_playing():
-                return
-            time.sleep(0.5)
+        import json as _json
+
+        def _json_rpc(method, params=None):
+            req = _json.dumps({'jsonrpc': '2.0', 'method': method,
+                               'params': params or {}, 'id': 1})
+            resp = xbmc.executeJSONRPC(req)
+            return _json.loads(resp)
+
+        # Leggi valori correnti per ripristino
+        original = {}
+        res = _json_rpc('Settings.GetSettingValue', {'setting': 'locale.audiolanguage'})
+        original['locale.audiolanguage'] = res.get('result', {}).get('value', '')
+        res = _json_rpc('Settings.GetSettingValue', {'setting': 'locale.subtitlelanguage'})
+        original['locale.subtitlelanguage'] = res.get('result', {}).get('value', '')
+        res = _json_rpc('Settings.GetSettingValue', {'setting': 'subtitles.languages'})
+        original['subtitles.languages'] = res.get('result', {}).get('value', '')
+
+        # Imposta lingua audio
+        if audio_lang and audio_lang in _LANG_KODI:
+            _json_rpc('Settings.SetSettingValue', {
+                'setting': 'locale.audiolanguage',
+                'value': _LANG_KODI[audio_lang]
+            })
+            logger.debug("_set_kodi_lang_prefs: audio -> %s" % _LANG_KODI[audio_lang])
+
+        # Imposta lingua sottotitoli
+        if sub_lang == '__off__':
+            # Kodi non ha un "forza spento" pre-play, gestiamo post-play
+            pass
+        elif sub_lang == '__on__':
+            pass  # Usa la lingua sottotitoli già impostata dall'utente
+        elif sub_lang in _LANG_KODI:
+            _json_rpc('Settings.SetSettingValue', {
+                'setting': 'locale.subtitlelanguage',
+                'value': _LANG_KODI[sub_lang]
+            })
+            logger.debug("_set_kodi_lang_prefs: subtitle lang -> %s" % _LANG_KODI[sub_lang])
+
+        return original
+
+    except Exception as e:
+        logger.error("_set_kodi_lang_prefs: errore: %s" % str(e))
+        return None
+
+
+def _restore_kodi_lang_prefs(original):
+    """Ripristina i valori di lingua Kodi salvati da _set_kodi_lang_prefs."""
+    if not original:
+        return
+    try:
+        import json as _json
+
+        def _json_rpc(method, params=None):
+            req = _json.dumps({'jsonrpc': '2.0', 'method': method,
+                               'params': params or {}, 'id': 1})
+            xbmc.executeJSONRPC(req)
+
+        for setting, value in original.items():
+            if value:
+                _json_rpc('Settings.SetSettingValue', {'setting': setting, 'value': value})
+                logger.debug("_restore_kodi_lang_prefs: %s -> %s" % (setting, value))
+    except Exception as e:
+        logger.error("_restore_kodi_lang_prefs: errore: %s" % str(e))
+
+
+def _apply_media_prefs(item, original_lang_prefs=None):
+    """
+    Applicata dopo onAVStarted:
+    - Ripristina le impostazioni lingua Kodi originali (dopo che Kodi ha già
+      selezionato le tracce con i valori temporanei impostati da _set_kodi_lang_prefs)
+    - Gestisce __on__/__off__ per la visualizzazione sottotitoli
+    """
+    try:
+        nfo = getattr(item, 'nfo', '') or ''
+        sub_lang = None  # None = nessuna preferenza esplicita
+        if nfo and str(nfo).endswith('tvshow.nfo') and filetools.exists(nfo):
+            from core import videolibrarytools
+            head_nfo, tvshow_item = videolibrarytools.read_nfo(nfo)
+            prefs = getattr(tvshow_item, 'tvshow_media_prefs', None)
+            if prefs:
+                sub_lang = prefs.get('sub_lang', '__on__')
+
+        # Se non c'è nulla da fare, esci subito
+        needs_av = (sub_lang in ('__on__', '__off__')) or (original_lang_prefs is not None)
+        if not needs_av:
+            return
 
         if not platformtools.is_playing():
             return
 
+        # Aspetta onAVStarted: a quel punto Kodi ha già selezionato le tracce
+        # usando le impostazioni temporanee che abbiamo impostato prima del play
+        class _AVMonitor(xbmc.Monitor):
+            def __init__(self):
+                xbmc.Monitor.__init__(self)
+                self.av_started = False
+            def onAVStarted(self):
+                self.av_started = True
+
+        monitor = _AVMonitor()
+        deadline = time.time() + 15
+        while not monitor.av_started and time.time() < deadline:
+            if monitor.abortRequested():
+                _restore_kodi_lang_prefs(original_lang_prefs)
+                return
+            time.sleep(0.1)
+
+        if not platformtools.is_playing():
+            _restore_kodi_lang_prefs(original_lang_prefs)
+            return
+
+        # Ora Kodi ha selezionato le tracce: ripristina le impostazioni originali
+        _restore_kodi_lang_prefs(original_lang_prefs)
+
+        # Gestisci __on__/__off__ sottotitoli
         player = xbmc.Player()
-
-        # Imposta la traccia audio
-        if audio_lang:
-            try:
-                streams = player.getAvailableAudioStreams()
-                aliases = _LANG_ALIASES.get(audio_lang, [audio_lang])
-                # Prima passa: cerca tracce non-FORCED
-                found = False
-                for i, label in enumerate(streams):
-                    s = label.lower()
-                    if 'forced' in s:
-                        continue
-                    for alias in aliases:
-                        if alias.lower() in s:
-                            player.setAudioStream(i)
-                            logger.debug("_apply_media_prefs: audio stream %d selezionato: %s" % (i, label))
-                            found = True
-                            break
-                    if found:
-                        break
-                # Seconda passa: accetta anche FORCED se non trovato nulla
-                if not found:
-                    for i, label in enumerate(streams):
-                        s = label.lower()
-                        for alias in aliases:
-                            if alias.lower() in s:
-                                player.setAudioStream(i)
-                                logger.debug("_apply_media_prefs: audio stream (forced) %d selezionato: %s" % (i, label))
-                                found = True
-                                break
-                        if found:
-                            break
-                if not found:
-                    logger.debug("_apply_media_prefs: nessuna traccia audio corrisponde a '%s'" % audio_lang)
-            except Exception as e:
-                logger.error("_apply_media_prefs: errore impostando audio: %s" % str(e))
-
-        # Imposta i sottotitoli
-        if sub_lang:
-            try:
-                if sub_lang == '__off__':
-                    # Forza sottotitoli spenti
-                    player.showSubtitles(False)
-                    logger.debug("_apply_media_prefs: sottotitoli disabilitati")
-                elif sub_lang == '__on__':
-                    # Abilita sottotitoli senza cambiare la traccia
-                    player.showSubtitles(True)
-                    logger.debug("_apply_media_prefs: sottotitoli abilitati (lingua default)")
-                else:
-                    streams = player.getAvailableSubtitleStreams()
-                    aliases = _LANG_ALIASES.get(sub_lang, [sub_lang])
-                    # Prima passa: cerca tracce non-FORCED
-                    found = False
-                    for i, label in enumerate(streams):
-                        s = label.lower()
-                        if 'forced' in s:
-                            continue
-                        for alias in aliases:
-                            if alias.lower() in s:
-                                player.setSubtitleStream(i)
-                                player.showSubtitles(True)
-                                logger.debug("_apply_media_prefs: sottotitolo stream %d selezionato: %s" % (i, label))
-                                found = True
-                                break
-                        if found:
-                            break
-                    # Seconda passa: accetta anche FORCED se non trovato nulla
-                    if not found:
-                        for i, label in enumerate(streams):
-                            s = label.lower()
-                            for alias in aliases:
-                                if alias.lower() in s:
-                                    player.setSubtitleStream(i)
-                                    player.showSubtitles(True)
-                                    logger.debug("_apply_media_prefs: sottotitolo stream (forced) %d selezionato: %s" % (i, label))
-                                    found = True
-                                    break
-                            if found:
-                                break
-                    if not found:
-                        logger.debug("_apply_media_prefs: nessun sottotitolo corrisponde a '%s'" % sub_lang)
-            except Exception as e:
-                logger.error("_apply_media_prefs: errore impostando sottotitoli: %s" % str(e))
+        if sub_lang == '__off__':
+            player.showSubtitles(False)
+            logger.debug("_apply_media_prefs: sottotitoli disabilitati")
+        elif sub_lang == '__on__':
+            player.showSubtitles(True)
+            logger.debug("_apply_media_prefs: sottotitoli abilitati (lingua default)")
 
     except Exception as e:
         logger.error("_apply_media_prefs: errore generale: %s" % str(e))
+        _restore_kodi_lang_prefs(original_lang_prefs)
 
 
 def mark_auto_as_watched(item):
@@ -164,7 +195,9 @@ def mark_auto_as_watched(item):
         while not platformtools.is_playing() and time.time() < time_limit:
             time.sleep(1)
 
-        _apply_media_prefs(item)
+        # Applica preferenze post-play e ripristina le impostazioni lingua
+        # DOPO onAVStarted (quando Kodi ha già selezionato le tracce)
+        _apply_media_prefs(item, getattr(item, '_original_lang_prefs', None))
 
         marked = False
         sync = False

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -6500,6 +6500,38 @@ msgctxt "#80050"
 msgid "Downloading..."
 msgstr ""
 
+msgctxt "#80051"
+msgid "Set Audio/Subtitles"
+msgstr ""
+
+msgctxt "#80052"
+msgid "No preference (Kodi default)"
+msgstr ""
+
+msgctxt "#80053"
+msgid "Disabled (force off)"
+msgstr ""
+
+msgctxt "#80054"
+msgid "Always enabled (default language)"
+msgstr ""
+
+msgctxt "#80055"
+msgid "Preferred AUDIO for \"%s\""
+msgstr ""
+
+msgctxt "#80056"
+msgid "Preferred SUBTITLES for \"%s\""
+msgstr ""
+
+msgctxt "#80057"
+msgid "Preferences saved"
+msgstr ""
+
+msgctxt "#80058"
+msgid "Cannot read series information"
+msgstr ""
+
 msgctxt "#90001"
 msgid "S4Me options"
 msgstr "S4Me options..."

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -6501,6 +6501,38 @@ msgctxt "#80050"
 msgid "Downloading..."
 msgstr "Download in corso..."
 
+msgctxt "#80051"
+msgid "Set Audio/Subtitles"
+msgstr "Imposta Audio/Sottotitoli"
+
+msgctxt "#80052"
+msgid "No preference (Kodi default)"
+msgstr "Nessuna preferenza (default Kodi)"
+
+msgctxt "#80053"
+msgid "Disabled (force off)"
+msgstr "Disabilitati (forza spenti)"
+
+msgctxt "#80054"
+msgid "Always enabled (default language)"
+msgstr "Sempre abilitati (lingua predefinita)"
+
+msgctxt "#80055"
+msgid "Preferred AUDIO for \"%s\""
+msgstr "AUDIO preferito per \"%s\""
+
+msgctxt "#80056"
+msgid "Preferred SUBTITLES for \"%s\""
+msgstr "SOTTOTITOLI preferiti per \"%s\""
+
+msgctxt "#80057"
+msgid "Preferences saved"
+msgstr "Preferenze salvate"
+
+msgctxt "#80058"
+msgid "Cannot read series information"
+msgstr "Impossibile leggere le informazioni della serie"
+
 msgctxt "#90001"
 msgid "S4Me options"
 msgstr "Opzioni di S4Me..."

--- a/specials/videolibrary.py
+++ b/specials/videolibrary.py
@@ -136,7 +136,8 @@ def get_results(nfo_path, root, Type, local=False):
             else: delete_text = config.get_localized_string(60019)
 
             item.context = [{"title": seen_text, "action": "mark_content_as_watched", "channel": "videolibrary",  "playcount": counter},
-                            {"title": delete_text, "action": "delete", "channel": "videolibrary", "multichannel": multichannel}]
+                            {"title": delete_text, "action": "delete", "channel": "videolibrary", "multichannel": multichannel},
+                            {"title": config.get_localized_string(80051), "action": "set_tvshow_media_prefs", "channel": "videolibrary"}]
         else:
             folder = "folder_tvshows"
             try:
@@ -182,6 +183,7 @@ def get_results(nfo_path, root, Type, local=False):
                             {"title": config.get_localized_string(70269), "action": "update_tvshow", "channel": "videolibrary"}]
             if item.local_episodes_path == "": item.context.append({"title": config.get_localized_string(80048), "action": "add_local_episodes", "channel": "videolibrary"})
             else: item.context.append({"title": config.get_localized_string(80049), "action": "remove_local_episodes", "channel": "videolibrary"})
+            item.context.append({"title": config.get_localized_string(80051), "action": "set_tvshow_media_prefs", "channel": "videolibrary"})
     else: item = Item()
     return item, value
 
@@ -997,6 +999,92 @@ def mark_tvshow_as_updatable(item, silent=False):
 
     if not silent:
         platformtools.itemlist_refresh()
+
+
+def set_tvshow_media_prefs(item):
+    """
+    Apre un dialogo per impostare la lingua audio preferita e la preferenza
+    dei sottotitoli per una serie TV. Le scelte vengono salvate nel tvshow.nfo
+    e applicate automaticamente ad ogni episodio durante la riproduzione.
+    """
+    logger.debug()
+
+    nfo_path = item.nfo
+    if not nfo_path:
+        nfo_path = filetools.join(item.path, "tvshow.nfo")
+
+    head_nfo, tvshow_item = videolibrarytools.read_nfo(nfo_path)
+    if not tvshow_item:
+        platformtools.dialog_notification(
+            config.get_localized_string(60010), config.get_localized_string(80058),
+            time=4000, sound=False)
+        return
+
+    title = tvshow_item.contentSerieName or tvshow_item.contentTitle or ""
+    prefs = getattr(tvshow_item, 'tvshow_media_prefs', None) or {}
+
+    # --- Passo 1: Lingua audio ---
+    no_pref = config.get_localized_string(80052)
+    audio_labels = [
+        no_pref,
+        "Italian", "English", "Spanish",
+        "French", "German", "Portuguese", "Japanese",
+    ]
+    audio_keys = ["", "ita", "eng", "spa", "fra", "deu", "por", "jpn"]
+
+    current_audio = prefs.get('audio_lang', '')
+    preselect_audio = audio_keys.index(current_audio) if current_audio in audio_keys else 0
+
+    audio_title = config.get_localized_string(80055) % title if title else config.get_localized_string(80055) % "?"
+    audio_idx = platformtools.dialog_select(
+        audio_title,
+        audio_labels,
+        preselect=preselect_audio
+    )
+    if audio_idx < 0:
+        return  # Utente ha premuto Annulla
+
+    # --- Passo 2: Preferenza sottotitoli ---
+    # __on__  = sempre abilitati senza forzare una lingua
+    # __off__ = sempre disabilitati
+    # ""      = nessuna preferenza (Kodi decide)
+    sub_labels = [
+        no_pref,
+        config.get_localized_string(80053),
+        config.get_localized_string(80054),
+        "Italian", "English", "Spanish",
+        "French", "German", "Portuguese",
+    ]
+    sub_keys = ["", "__off__", "__on__", "ita", "eng", "spa", "fra", "deu", "por"]
+
+    current_sub = prefs.get('sub_lang', '__on__')
+    preselect_sub = sub_keys.index(current_sub) if current_sub in sub_keys else 2  # default: __on__
+
+    sub_title = config.get_localized_string(80056) % title if title else config.get_localized_string(80056) % "?"
+    sub_idx = platformtools.dialog_select(
+        sub_title,
+        sub_labels,
+        preselect=preselect_sub
+    )
+    if sub_idx < 0:
+        return  # Utente ha premuto Annulla
+
+    # --- Salvataggio nel tvshow.nfo ---
+    tvshow_item.tvshow_media_prefs = {
+        'audio_lang': audio_keys[audio_idx],
+        'sub_lang':   sub_keys[sub_idx],
+    }
+    filetools.write(nfo_path, head_nfo + tvshow_item.tojson())
+
+    platformtools.dialog_notification(
+        config.get_localized_string(80057),
+        u"%s: %s | %s: %s" % (
+            "Audio", audio_labels[audio_idx],
+            "Subs",  sub_labels[sub_idx]
+        ),
+        time=4000, sound=False
+    )
+    platformtools.itemlist_refresh()
 
 
 def delete(item):

--- a/specials/videolibrary.py
+++ b/specials/videolibrary.py
@@ -1057,8 +1057,8 @@ def set_tvshow_media_prefs(item):
     ]
     sub_keys = ["", "__off__", "__on__", "ita", "eng", "spa", "fra", "deu", "por"]
 
-    current_sub = prefs.get('sub_lang', '__on__')
-    preselect_sub = sub_keys.index(current_sub) if current_sub in sub_keys else 2  # default: __on__
+    current_sub = prefs.get('sub_lang', '')
+    preselect_sub = sub_keys.index(current_sub) if current_sub in sub_keys else 0  # default: nessuna preferenza
 
     sub_title = config.get_localized_string(80056) % title if title else config.get_localized_string(80056) % "?"
     sub_idx = platformtools.dialog_select(

--- a/specials/videolibrary.py
+++ b/specials/videolibrary.py
@@ -1045,17 +1045,16 @@ def set_tvshow_media_prefs(item):
         return  # Utente ha premuto Annulla
 
     # --- Passo 2: Preferenza sottotitoli ---
-    # __on__  = sempre abilitati senza forzare una lingua
     # __off__ = sempre disabilitati
     # ""      = nessuna preferenza (Kodi decide)
+    # lingua specifica = imposta la traccia sottotitoli
     sub_labels = [
         no_pref,
         config.get_localized_string(80053),
-        config.get_localized_string(80054),
         "Italian", "English", "Spanish",
         "French", "German", "Portuguese",
     ]
-    sub_keys = ["", "__off__", "__on__", "ita", "eng", "spa", "fra", "deu", "por"]
+    sub_keys = ["", "__off__", "ita", "eng", "spa", "fra", "deu", "por"]
 
     current_sub = prefs.get('sub_lang', '')
     preselect_sub = sub_keys.index(current_sub) if current_sub in sub_keys else 0  # default: nessuna preferenza


### PR DESCRIPTION
## Descrizione

Aggiunge la possibilità di impostare una lingua audio preferita e un comportamento per i sottotitoli per ogni serie TV individualmente, che si applica a tutti gli episodi della serie, senza dover modificare singolarmente ogni episodio a mano, direttamente dal menu contestuale della videoteca S4Me.

## Come funziona

1. **Tasto destro sul titolo di una serie** nell'elenco della videoteca S4Me → nuova opzione "Imposta Audio/Sottotitoli" (localizzata)
2. Appaiono due dialoghi in sequenza:
   - Scelta della **lingua audio** preferita (Italiano, English, Español, ecc. oppure nessuna preferenza)
   - Scelta del **comportamento sottotitoli**: sempre abilitati (default), sempre disabilitati, una lingua specifica, oppure nessuna preferenza
3. Le impostazioni vengono salvate nel `tvshow.nfo` della serie come `tvshow_media_prefs`
4. **Ad ogni riproduzione di un episodio**, la preferenza viene applicata.

## Dettagli tecnici

- **Approccio JSON-RPC pre-play**: prima di avviare la riproduzione, `locale.audiolanguage` e `locale.subtitlelanguage` vengono impostati temporaneamente tramite `Settings.SetSettingValue`. Kodi seleziona così la traccia giusta fin dall'inizio.
- **Ripristino dopo onAVStarted**: dopo che Kodi ha aperto lo stream e selezionato le tracce, le impostazioni originali di Kodi vengono ripristinate, in modo da non interferire con altre riproduzioni.
- **`__on__`/`__off__` sottotitoli**: gestiti post-play tramite `showSubtitles()` subito dopo `onAVStarted`.
- **Localizzazione**: tutte le stringhe UI usano il sistema `.po` dell'addon, con traduzioni complete in inglese e italiano.
- **Nessuna modifica allo schema**: `tvshow_media_prefs` è salvato come attributo dinamico sull'oggetto `Item`, serializzato/deserializzato automaticamente dai metodi `tojson()`/`fromjson()` già esistenti.

## File modificati

- `specials/videolibrary.py` — nuova azione `set_tvshow_media_prefs()` + voce nel menu contestuale
- `platformcode/platformtools.py` — chiamata a `_set_kodi_lang_prefs()` prima di `xbmc_player.play()`
- `platformcode/xbmc_videolibrary.py` — nuove funzioni `_set_kodi_lang_prefs()`, `_restore_kodi_lang_prefs()`, `_apply_media_prefs()`
- `platformcode/contextmenu/tvshow_options.py` — voce nel Quick menu
- `resources/language/resource.language.en_gb/strings.po` — stringhe in inglese
- `resources/language/resource.language.it_it/strings.po` — stringhe in italiano
