### PR TITLE
Security: DLL/shared-library hijacking by loading ChakraCore from current working directory

### DIFF
--- a/lib/cloudscraper/interpreters/chakracore.py
+++ b/lib/cloudscraper/interpreters/chakracore.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import os
 import sys
 import ctypes.util
 
@@ -22,21 +21,12 @@ class ChallengeInterpreter(JavaScriptInterpreter):
     # ------------------------------------------------------------------------------- #
 
     def eval(self, body, domain):
-        chakraCoreLibrary = None
-
-        # check current working directory.
-        for _libraryFile in ['libChakraCore.so', 'libChakraCore.dylib', 'ChakraCore.dll']:
-            if os.path.isfile(os.path.join(os.getcwd(), _libraryFile)):
-                chakraCoreLibrary = os.path.join(os.getcwd(), _libraryFile)
-                continue
-
-        if not chakraCoreLibrary:
-            chakraCoreLibrary = ctypes.util.find_library('ChakraCore')
+        chakraCoreLibrary = ctypes.util.find_library('ChakraCore')
 
         if not chakraCoreLibrary:
             sys.tracebacklimit = 0
             raise RuntimeError(
-                'ChakraCore library not found in current path or any of your system library paths, '
+                'ChakraCore library not found in any of your system library paths, '
                 'please download from https://www.github.com/VeNoMouS/cloudscraper/tree/ChakraCore/, '
                 'or https://github.com/Microsoft/ChakraCore/'
             )


### PR DESCRIPTION
## Summary

Security: DLL/shared-library hijacking by loading ChakraCore from current working directory

## Problem

**Severity**: `Critical` | **File**: `lib/cloudscraper/interpreters/chakracore.py:L24`

The interpreter searches the current working directory first for `libChakraCore.so`/`libChakraCore.dylib`/`ChakraCore.dll` and loads it via `CDLL`. If an attacker can place a malicious library in the working directory, arbitrary native code execution is possible.

## Solution

Do not load libraries from the current working directory. Restrict loading to trusted absolute paths (e.g., packaged directory with integrity checks/signatures) or system library resolution only.

## Changes

- `lib/cloudscraper/interpreters/chakracore.py` (modified)